### PR TITLE
Get distance Between Actor and a Scene Component

### DIFF
--- a/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.cpp
+++ b/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.cpp
@@ -10,13 +10,22 @@ EStateTreeRunStatus FAIExtStateTreeTaskGetDistanceBetweenActors::Tick( FStateTre
 
     auto & instance_data = context.GetInstanceData( *this );
 
-    if ( instance_data.Actor1 != nullptr && instance_data.OtherComponent != nullptr )
+    if ( instance_data.Actor1 == nullptr )
+    {
+        return EStateTreeRunStatus::Failed;
+    }
+
+    if ( instance_data.OtherComponent != nullptr )
     {
         instance_data.Distance = FVector::Distance( instance_data.Actor1->GetActorLocation(), instance_data.OtherComponent->GetComponentLocation() );
     }
-    else if ( instance_data.Actor1 != nullptr && instance_data.Actor2 != nullptr )
+    else if ( instance_data.Actor2 != nullptr )
     {
         instance_data.Distance = FVector::Distance( instance_data.Actor1->GetActorLocation(), instance_data.Actor2->GetActorLocation() );
+    }
+    else
+    {
+        return EStateTreeRunStatus::Failed;
     }
 
     return EStateTreeRunStatus::Running;

--- a/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.cpp
+++ b/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.cpp
@@ -10,7 +10,11 @@ EStateTreeRunStatus FAIExtStateTreeTaskGetDistanceBetweenActors::Tick( FStateTre
 
     auto & instance_data = context.GetInstanceData( *this );
 
-    if ( instance_data.Actor1 != nullptr && instance_data.Actor2 != nullptr )
+    if ( instance_data.Actor1 != nullptr && instance_data.OtherComponent != nullptr )
+    {
+        instance_data.Distance = FVector::Distance( instance_data.Actor1->GetActorLocation(), instance_data.OtherComponent->GetComponentLocation() );
+    }
+    else if ( instance_data.Actor1 != nullptr && instance_data.Actor2 != nullptr )
     {
         instance_data.Distance = FVector::Distance( instance_data.Actor1->GetActorLocation(), instance_data.Actor2->GetActorLocation() );
     }

--- a/Source/AIExtensions/Public/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.h
+++ b/Source/AIExtensions/Public/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.h
@@ -22,7 +22,7 @@ struct AIEXTENSIONS_API FAIExtStateTreeTaskGetDistanceBetweenActorsInstanceData
     UPROPERTY( EditAnywhere, Category = "Context" )
     TObjectPtr< AActor > Actor2 = nullptr;
 
-    /** The Scene Component */
+    /** The Scene Component. Has precedence over Actor2 */
     UPROPERTY( EditAnywhere, Category = "Input" )
     TObjectPtr< USceneComponent > OtherComponent = nullptr;
 

--- a/Source/AIExtensions/Public/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.h
+++ b/Source/AIExtensions/Public/StateTree/Tasks/AIExtStateTreeTaskGetDistanceBetweenActors.h
@@ -22,6 +22,10 @@ struct AIEXTENSIONS_API FAIExtStateTreeTaskGetDistanceBetweenActorsInstanceData
     UPROPERTY( EditAnywhere, Category = "Context" )
     TObjectPtr< AActor > Actor2 = nullptr;
 
+    /** The Scene Component */
+    UPROPERTY( EditAnywhere, Category = "Input" )
+    TObjectPtr< USceneComponent > OtherComponent = nullptr;
+
     /** The distance between the actors  */
     UPROPERTY( EditAnywhere, Category = "Output" )
     float Distance = 0.0f;


### PR DESCRIPTION
Added a Scene Component as Input so we can get the Distance between Actor1 and the SceneComponent if it is not null, instead of the distance between Actor1 and Actor2.

SceneComponent property is set in "Input" Category so the State Tree can compile even if the SceneComponent is not set.