### PR TITLE
Fix STT Activate Ability

### DIFF
--- a/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskActivateAbility.cpp
+++ b/Source/AIExtensions/Private/StateTree/Tasks/AIExtStateTreeTaskActivateAbility.cpp
@@ -99,9 +99,8 @@ EStateTreeRunStatus FAIExtStateTreeTaskActivateAbility::EnterState( FStateTreeEx
     }
     else
     {
-        instance_data.AbilitySystemComponent->TryActivateAbility( instance_data.AbilitySpecHandle );
+        could_activate_ability = instance_data.AbilitySystemComponent->TryActivateAbility( instance_data.AbilitySpecHandle );
     }
-    
 
     if ( !could_activate_ability && instance_data.bEndTaskWhenAbilityEnds )
     {


### PR DESCRIPTION
If the ability was not activated from event it was instantly ending the task ( and the ability if wanted ). 